### PR TITLE
Improve getting favicon

### DIFF
--- a/favicon-request.js
+++ b/favicon-request.js
@@ -94,7 +94,7 @@ function readHtml(stream) {
 function getIconUrl(html, domain) {
     const MAX_SIZE = 96;
     let match;
-    const re = /<link\s+[^>]*rel=["']?icon["']?[^>]*>/g;
+    const re = /<link\s+[^>]*rel=["']?(?:shortcut )?icon["']?[^>]*>/g;
     let iconHref, iconSize = 0;
     do {
         match = re.exec(html);

--- a/favicon-request.js
+++ b/favicon-request.js
@@ -63,7 +63,7 @@ function loadResource(url, redirectNum) {
                 } else {
                     resolve(loadResource(srvRes.headers.location, (redirectNum || 0) + 1));
                 }
-            } else if (srvRes.statusCode === 200) {
+            } else if (srvRes.statusCode === 200 && srvRes.headers['content-type'].startsWith('image/')) {
                 resolve(srvRes);
             } else {
                 reject('Status ' + srvRes.statusCode);

--- a/favicon-request.js
+++ b/favicon-request.js
@@ -122,6 +122,9 @@ function getIconUrl(html, domain) {
             if (!iconHref.startsWith('/')) {
                 iconHref = '/' + iconHref;
             }
+            if (iconHref.startsWith('//')) {
+                return 'http:' + iconHref;
+            }
             return 'http://' + domain + iconHref;
         }
     }


### PR DESCRIPTION
Hi.
I created this PR because of keeweb.
I made some improvements regarding getting favicon.

* handling two forward slashes
`<link rel="icon" href="//sample.com/favicon.ico">`

* 'shortcut icon' support
`<link rel="shortcut icon" href="/favicon.ico" />`

* also check content-type and loose first restriction
I found some sites returned 'status code 200' even if favicon.ico doesn't exist.
For example
http://castbox.fm/favicon.ico
http://dazn.com/favicon.ico
These sites redirect to not found page, but return status code 200 finally.
Because of this, the program doesn't try to parse html.
Therefore I added checking content-type as well, 
and if 200 status returned and image not returned when first check, I changed program to proceed to parse html.

I deployed it on Heroku for test and confirmed its operation.
https://lit-citadel-32861.herokuapp.com/